### PR TITLE
feat: Add post-install commands to admin panel

### DIFF
--- a/app/Http/Controllers/Admin/BoilerplateController.php
+++ b/app/Http/Controllers/Admin/BoilerplateController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\BoilerplateCommand;
 use App\Models\BoilerplateComposerPackage;
 use App\Models\BoilerplateDockerService;
 use App\Models\BoilerplateFile;
@@ -22,6 +23,7 @@ class BoilerplateController extends Controller
             'composerPackages' => BoilerplateComposerPackage::query()->orderBy('package')->get(),
             'npmPackages' => BoilerplateNpmPackage::query()->orderBy('package')->get(),
             'dockerServices' => BoilerplateDockerService::query()->orderBy('name')->get(),
+            'commands' => BoilerplateCommand::query()->orderBy('sort_order')->get(),
         ]);
     }
 
@@ -289,5 +291,71 @@ class BoilerplateController extends Controller
         $service->delete();
 
         return redirect()->route('admin.docker-services')->with('success', 'Docker service removed.');
+    }
+
+    // --- Post-Install Commands ---
+
+    public function commands(): View
+    {
+        return view('admin.commands', [
+            'commands' => BoilerplateCommand::query()->orderBy('sort_order')->get(),
+        ]);
+    }
+
+    public function storeCommand(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'command' => ['required', 'string'],
+            'sort_order' => ['integer'],
+            'enabled' => ['boolean'],
+        ]);
+
+        BoilerplateCommand::query()->create([
+            'name' => $validated['name'],
+            'command' => $validated['command'],
+            'sort_order' => $validated['sort_order'] ?? 0,
+            'enabled' => $request->boolean('enabled', true),
+        ]);
+
+        return redirect()->route('admin.commands')->with('success', 'Command added.');
+    }
+
+    public function editCommand(BoilerplateCommand $command): View
+    {
+        return view('admin.command-edit', ['command' => $command]);
+    }
+
+    public function updateCommand(Request $request, BoilerplateCommand $command): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'command' => ['required', 'string'],
+            'sort_order' => ['integer'],
+            'enabled' => ['boolean'],
+        ]);
+
+        $command->update([
+            'name' => $validated['name'],
+            'command' => $validated['command'],
+            'sort_order' => $validated['sort_order'] ?? 0,
+            'enabled' => $request->boolean('enabled'),
+        ]);
+
+        return redirect()->route('admin.commands')->with('success', 'Command updated.');
+    }
+
+    public function toggleCommand(BoilerplateCommand $command): RedirectResponse
+    {
+        $command->update(['enabled' => ! $command->enabled]);
+
+        return redirect()->route('admin.commands');
+    }
+
+    public function destroyCommand(BoilerplateCommand $command): RedirectResponse
+    {
+        $command->delete();
+
+        return redirect()->route('admin.commands')->with('success', 'Command removed.');
     }
 }

--- a/app/Http/Controllers/InstallScriptController.php
+++ b/app/Http/Controllers/InstallScriptController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\BoilerplateCommand;
 use App\Models\BoilerplateComposerPackage;
 use App\Models\BoilerplateDockerService;
 use App\Models\BoilerplateFile;
@@ -56,6 +57,11 @@ class InstallScriptController extends Controller
             ->where('config', '!=', '')
             ->get();
 
+        $commands = BoilerplateCommand::query()
+            ->where('enabled', true)
+            ->orderBy('sort_order')
+            ->get();
+
         $hasVitePlugin = $npmPackages->contains(fn ($pkg): bool => $pkg->package === '@tailwindcss/vite');
 
         $servicesString = implode(',', $services);
@@ -82,6 +88,7 @@ class InstallScriptController extends Controller
             'sailServiceOverrides' => $sailServiceOverrides,
             'hasVitePlugin' => $hasVitePlugin,
             'placeholders' => $placeholders,
+            'commands' => $commands,
             'dockerImage' => config('boilerplate.docker_image'),
         ])->render();
 

--- a/app/Models/BoilerplateCommand.php
+++ b/app/Models/BoilerplateCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\BoilerplateCommandFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'command', 'sort_order', 'enabled'])]
+class BoilerplateCommand extends Model
+{
+    /** @use HasFactory<BoilerplateCommandFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+        ];
+    }
+}

--- a/database/factories/BoilerplateCommandFactory.php
+++ b/database/factories/BoilerplateCommandFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\BoilerplateCommand;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<BoilerplateCommand>
+ */
+class BoilerplateCommandFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->words(2, true),
+            'command' => fake()->word().'_'.fake()->word(),
+            'sort_order' => 0,
+            'enabled' => true,
+        ];
+    }
+}

--- a/database/migrations/2026_03_19_004440_create_boilerplate_commands_table.php
+++ b/database/migrations/2026_03_19_004440_create_boilerplate_commands_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('boilerplate_commands', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('command');
+            $table->integer('sort_order')->default(0);
+            $table->boolean('enabled')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('boilerplate_commands');
+    }
+};

--- a/database/seeders/BoilerplateCommandSeeder.php
+++ b/database/seeders/BoilerplateCommandSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class BoilerplateCommandSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // No default commands — add via admin GUI
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -28,6 +28,7 @@ class DatabaseSeeder extends Seeder
             BoilerplateComposerPackageSeeder::class,
             BoilerplateNpmPackageSeeder::class,
             BoilerplateDockerServiceSeeder::class,
+            BoilerplateCommandSeeder::class,
         ]);
     }
 }

--- a/resources/views/admin/command-edit.blade.php
+++ b/resources/views/admin/command-edit.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.admin')
+
+@section('title', 'Edit Command — ' . $command->name)
+
+@section('content')
+    <div class="mb-4">
+        <a href="{{ route('admin.commands') }}" class="text-gray-400 hover:text-cyan-400 text-sm">&larr; Back to Commands</a>
+    </div>
+
+    <h1 class="text-2xl font-bold text-cyan-400 mb-6">Edit: {{ $command->name }}</h1>
+
+    <x-placeholder-info />
+
+    <form action="{{ route('admin.commands.update', $command) }}" method="POST" class="bg-gray-800 rounded-lg p-6 border border-gray-700 space-y-4">
+        @csrf
+        @method('PUT')
+        <div>
+            <label for="name" class="block text-sm text-gray-400 mb-1">Name</label>
+            <input type="text" name="name" id="name" value="{{ $command->name }}" required class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white focus:border-cyan-500 focus:outline-none font-mono text-sm">
+        </div>
+        <div>
+            <label for="command" class="block text-sm text-gray-400 mb-1">Command</label>
+            <textarea name="command" id="command" rows="6" required class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white placeholder-gray-500 focus:border-cyan-500 focus:outline-none font-mono text-sm">{{ $command->command }}</textarea>
+        </div>
+        <div>
+            <label for="sort_order" class="block text-sm text-gray-400 mb-1">Sort order</label>
+            <input type="number" name="sort_order" id="sort_order" value="{{ $command->sort_order }}" class="w-32 bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white focus:border-cyan-500 focus:outline-none">
+        </div>
+        <div>
+            <label class="flex items-center gap-2 text-sm">
+                <input type="hidden" name="enabled" value="0">
+                <input type="checkbox" name="enabled" value="1" {{ $command->enabled ? 'checked' : '' }} class="rounded">
+                <span class="text-gray-400">Enabled</span>
+            </label>
+        </div>
+        <div class="flex items-center justify-between pt-2">
+            <button type="submit" class="bg-cyan-600 hover:bg-cyan-700 text-white px-4 py-2 rounded font-medium">Save</button>
+        </div>
+    </form>
+
+    <form action="{{ route('admin.commands.destroy', $command) }}" method="POST" class="mt-4" onsubmit="return confirm('Delete this command?')">
+        @csrf
+        @method('DELETE')
+        <button type="submit" class="text-red-400 hover:text-red-300 text-sm">Delete this command</button>
+    </form>
+@endsection

--- a/resources/views/admin/commands.blade.php
+++ b/resources/views/admin/commands.blade.php
@@ -1,0 +1,55 @@
+@extends('layouts.admin')
+
+@section('title', 'Post-Install Commands')
+
+@section('content')
+    <h1 class="text-2xl font-bold text-cyan-400 mb-6">Post-Install Commands</h1>
+    <p class="text-gray-400 text-sm mb-6">Shell commands that run as the final step of the install script, after all containers are built. Failed commands become warnings and do not abort the installation.</p>
+
+    <x-placeholder-info />
+
+    {{-- Add new --}}
+    <form action="{{ route('admin.commands.store') }}" method="POST" class="bg-gray-800 rounded-lg p-6 border border-gray-700 mb-8">
+        @csrf
+        <div class="space-y-4">
+            <div>
+                <label for="name" class="block text-sm text-gray-400 mb-1">Name</label>
+                <input type="text" name="name" id="name" required placeholder="e.g. Assign ports" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white placeholder-gray-500 focus:border-cyan-500 focus:outline-none">
+            </div>
+            <div>
+                <label for="command" class="block text-sm text-gray-400 mb-1">Command</label>
+                <textarea name="command" id="command" rows="3" required placeholder="e.g. assign_forward_instance_ports" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white placeholder-gray-500 focus:border-cyan-500 focus:outline-none font-mono text-sm"></textarea>
+            </div>
+            <div>
+                <label for="sort_order" class="block text-sm text-gray-400 mb-1">Sort order</label>
+                <input type="number" name="sort_order" id="sort_order" value="0" class="w-32 bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white focus:border-cyan-500 focus:outline-none">
+            </div>
+            <button type="submit" class="bg-cyan-600 hover:bg-cyan-700 text-white px-4 py-2 rounded font-medium">Add Command</button>
+        </div>
+    </form>
+
+    {{-- List --}}
+    <div class="bg-gray-800 rounded-lg border border-gray-700 divide-y divide-gray-700">
+        @forelse ($commands as $command)
+            <div class="flex items-center justify-between px-6 py-3">
+                <div class="flex items-center gap-4">
+                    <span class="text-gray-500 text-xs font-mono w-6">{{ $command->sort_order }}</span>
+                    <a href="{{ route('admin.commands.edit', $command) }}" class="text-white hover:text-cyan-400 font-mono text-sm">{{ $command->name }}</a>
+                </div>
+                <div class="flex items-center gap-3">
+                    <form action="{{ route('admin.commands.toggle', $command) }}" method="POST">
+                        @csrf
+                        @method('PATCH')
+                        <button type="submit" class="px-2 py-1 rounded text-xs font-medium {{ $command->enabled ? 'bg-green-900/50 text-green-400 border border-green-700' : 'bg-gray-700 text-gray-500 border border-gray-600' }}">
+                            {{ $command->enabled ? 'Enabled' : 'Disabled' }}
+                        </button>
+                    </form>
+                </div>
+            </div>
+        @empty
+            <div class="p-8 text-center text-gray-500">
+                No post-install commands configured.
+            </div>
+        @endforelse
+    </div>
+@endsection

--- a/resources/views/admin/file-edit.blade.php
+++ b/resources/views/admin/file-edit.blade.php
@@ -9,6 +9,8 @@
 
     <h1 class="text-2xl font-bold text-cyan-400 mb-6">Edit: {{ $file->path }}</h1>
 
+    <x-placeholder-info />
+
     <form action="{{ route('admin.files.update', $file) }}" method="POST" class="bg-gray-800 rounded-lg p-6 border border-gray-700 space-y-4">
         @csrf
         @method('PUT')
@@ -19,12 +21,6 @@
         <div>
             <label for="content" class="block text-sm text-gray-400 mb-1">Content (leave empty for directory)</label>
             <textarea name="content" id="content" rows="12" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white placeholder-gray-500 focus:border-cyan-500 focus:outline-none font-mono text-sm">{{ $file->content }}</textarea>
-            <div class="text-gray-500 text-xs mt-1">
-                Available placeholders:
-                @foreach (config('boilerplate.placeholders') as $key => $def)
-                    <div><code class="text-cyan-400">{{ $key }}</code> — {{ $def['description'] }}</div>
-                @endforeach
-            </div>
         </div>
         <div>
             <label class="flex items-center gap-2 text-sm">

--- a/resources/views/admin/files.blade.php
+++ b/resources/views/admin/files.blade.php
@@ -5,6 +5,8 @@
 @section('content')
     <h1 class="text-2xl font-bold text-cyan-400 mb-6">Custom Files</h1>
 
+    <x-placeholder-info />
+
     {{-- Add new --}}
     <form action="{{ route('admin.files.store') }}" method="POST" class="bg-gray-800 rounded-lg p-6 border border-gray-700 mb-8">
         @csrf

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -40,5 +40,12 @@
             <span class="text-cyan-400 font-mono text-2xl">{{ $dockerServices->where('enabled', true)->count() }}</span>
             <span class="text-gray-500 text-sm"> / {{ $dockerServices->count() }} active</span>
         </a>
+
+        <a href="{{ route('admin.commands') }}" class="block bg-gray-800 rounded-lg p-6 border border-gray-700 hover:border-cyan-500 transition-colors">
+            <h2 class="text-lg font-semibold text-white mb-2">Post-Install Commands</h2>
+            <p class="text-gray-400 text-sm mb-4">Shell commands run after installation</p>
+            <span class="text-cyan-400 font-mono text-2xl">{{ $commands->where('enabled', true)->count() }}</span>
+            <span class="text-gray-500 text-sm"> / {{ $commands->count() }} active</span>
+        </a>
     </div>
 @endsection

--- a/resources/views/components/placeholder-info.blade.php
+++ b/resources/views/components/placeholder-info.blade.php
@@ -1,0 +1,8 @@
+<div class="bg-gray-800/50 rounded-lg p-4 border border-gray-700 mb-6">
+    <p class="text-gray-400 text-sm mb-2">Available placeholders:</p>
+    <ul class="space-y-1">
+        @foreach (config('boilerplate.placeholders') as $key => $def)
+            <li><span class="font-mono text-xs text-cyan-400 bg-gray-700 px-2 py-1 rounded">{{ $key }}</span> <span class="text-gray-500 text-xs">{{ $def['description'] }}</span></li>
+        @endforeach
+    </ul>
+</div>

--- a/resources/views/install.php
+++ b/resources/views/install.php
@@ -210,6 +210,14 @@ retry 2 5 ./vendor/bin/sail build || warn "Sail build had errors — run manuall
 # Fix permissions again (sail build may create files as root)
 $SUDO chown -R $USER: .
 
+<?php if ($commands->isNotEmpty()) { ?>
+# Post-install commands
+<?php foreach ($commands as $cmd) { ?>
+echo -e "${YELLOW}Running: <?php echo e($cmd->name); ?>...${NC}"
+<?php echo str_replace(array_keys($placeholders), array_values($placeholders), $cmd->command); ?> || warn "Command failed: <?php echo e($cmd->name); ?>"
+<?php } ?>
+<?php } ?>
+
 # Summary
 echo ""
 if [ ${#WARNINGS[@]} -eq 0 ]; then

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -17,6 +17,7 @@
                     <a href="{{ route('admin.composer-packages') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Composer</a>
                     <a href="{{ route('admin.npm-packages') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">npm</a>
                     <a href="{{ route('admin.docker-services') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Docker Services</a>
+                    <a href="{{ route('admin.commands') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Commands</a>
                     <span class="text-gray-600">|</span>
                     <a href="{{ url('/') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">&larr; Front Page</a>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,11 +2,12 @@
 
 use App\Http\Controllers\Admin\BoilerplateController;
 use App\Http\Controllers\InstallScriptController;
+use App\Models\BoilerplateSailService;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome', [
-        'services' => \App\Models\BoilerplateSailService::query()->orderBy('name')->get(),
+        'services' => BoilerplateSailService::query()->orderBy('name')->get(),
     ]);
 });
 
@@ -44,6 +45,13 @@ Route::prefix('admin')->name('admin.')->group(function () {
     Route::get('/docker-services/{service}/edit', [BoilerplateController::class, 'editDockerService'])->name('docker-services.edit');
     Route::patch('/docker-services/{service}/toggle', [BoilerplateController::class, 'toggleDockerService'])->name('docker-services.toggle');
     Route::delete('/docker-services/{service}', [BoilerplateController::class, 'destroyDockerService'])->name('docker-services.destroy');
+
+    Route::get('/commands', [BoilerplateController::class, 'commands'])->name('commands');
+    Route::post('/commands', [BoilerplateController::class, 'storeCommand'])->name('commands.store');
+    Route::get('/commands/{command}/edit', [BoilerplateController::class, 'editCommand'])->name('commands.edit');
+    Route::put('/commands/{command}', [BoilerplateController::class, 'updateCommand'])->name('commands.update');
+    Route::patch('/commands/{command}/toggle', [BoilerplateController::class, 'toggleCommand'])->name('commands.toggle');
+    Route::delete('/commands/{command}', [BoilerplateController::class, 'destroyCommand'])->name('commands.destroy');
 });
 
 // Install script endpoint — must be last to avoid catching other routes

--- a/tests/Feature/InstallScriptTest.php
+++ b/tests/Feature/InstallScriptTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\BoilerplateCommand;
 use App\Models\BoilerplateComposerPackage;
 use App\Models\BoilerplateDockerService;
 use App\Models\BoilerplateFile;
@@ -312,5 +313,70 @@ class InstallScriptTest extends TestCase
         // Packages and PARTIAL_FAIL pattern inside the same docker run
         $response->assertSee('laravel/pail', false);
         $response->assertSee('PARTIAL_FAIL:', false);
+    }
+
+    public function test_install_script_includes_post_install_commands(): void
+    {
+        BoilerplateSailService::factory()->create(['name' => 'mysql', 'enabled' => true]);
+        BoilerplateCommand::factory()->create(['name' => 'Assign ports', 'command' => 'assign_forward_instance_ports', 'enabled' => true]);
+
+        $response = $this->get('/my-app');
+
+        $response->assertStatus(200);
+        $response->assertSee('assign_forward_instance_ports', false);
+        $response->assertSee('Running: Assign ports', false);
+    }
+
+    public function test_install_script_skips_disabled_commands(): void
+    {
+        BoilerplateSailService::factory()->create(['name' => 'mysql', 'enabled' => true]);
+        BoilerplateCommand::factory()->create(['name' => 'Disabled cmd', 'command' => 'should_not_appear', 'enabled' => false]);
+
+        $response = $this->get('/my-app');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('should_not_appear', false);
+    }
+
+    public function test_install_script_runs_commands_in_sort_order(): void
+    {
+        BoilerplateSailService::factory()->create(['name' => 'mysql', 'enabled' => true]);
+        BoilerplateCommand::factory()->create(['name' => 'Second', 'command' => 'run_second', 'sort_order' => 10, 'enabled' => true]);
+        BoilerplateCommand::factory()->create(['name' => 'First', 'command' => 'run_first', 'sort_order' => 1, 'enabled' => true]);
+
+        $response = $this->get('/my-app');
+        $content = $response->getContent();
+
+        $response->assertStatus(200);
+        $firstPos = strpos($content, 'run_first');
+        $secondPos = strpos($content, 'run_second');
+        $this->assertLessThan($secondPos, $firstPos, 'Commands must run in sort_order');
+    }
+
+    public function test_install_script_replaces_placeholders_in_commands(): void
+    {
+        BoilerplateSailService::factory()->create(['name' => 'mysql', 'enabled' => true]);
+        BoilerplateCommand::factory()->create([
+            'name' => 'Setup ports',
+            'command' => 'assign_ports :APP_NAME: :SERVICES:',
+            'enabled' => true,
+        ]);
+
+        $response = $this->get('/my-app');
+
+        $response->assertStatus(200);
+        $response->assertSee('assign_ports my-app mysql', false);
+        $response->assertDontSee(':APP_NAME:', false);
+    }
+
+    public function test_install_script_commands_use_warn_on_failure(): void
+    {
+        BoilerplateSailService::factory()->create(['name' => 'mysql', 'enabled' => true]);
+        BoilerplateCommand::factory()->create(['name' => 'My cmd', 'command' => 'do_something', 'enabled' => true]);
+
+        $response = $this->get('/my-app');
+
+        $response->assertStatus(200);
+        $response->assertSee('|| warn "Command failed: My cmd"', false);
     }
 }


### PR DESCRIPTION
## Summary

Adds a new "Post-Install Commands" entity to the admin panel, allowing users to configure shell commands that run as the final step of the generated install script.

## Changes

- **New `BoilerplateCommand` entity** — model, migration, factory, seeder with full CRUD admin UI (list, add, edit, toggle, delete)
- **Placeholder support in commands** — `:APP_NAME:` and `:SERVICES:` are resolved at install time, same as custom files
- **Reusable `<x-placeholder-info />` Blade component** — replaces inline placeholder info across files, file-edit, commands, and command-edit admin pages
- **Nav bar and dashboard** — "Commands" link added to admin nav and dashboard overview card
- **Install script injection** — enabled commands run after final `chown`, before summary output; failures become warnings (non-fatal)
- **5 new tests** — covers command injection, disabled filtering, sort order, placeholder replacement, and warn-on-failure pattern

## Testing

- `php artisan test --compact --filter=InstallScript` — 30 tests, 83 assertions passing
- `php artisan test --compact` — 57 tests, 131 assertions passing (full suite)
- `vendor/bin/pint --dirty` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)