### PR TITLE
feat: Add Docker image build and GHCR deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules/
+vendor/
+.env
+database/*.sqlite
+storage/logs/*
+storage/framework/cache/*
+storage/framework/sessions/*
+storage/framework/views/*
+.git/
+.claude/
+.idea/
+.vscode/
+tests/

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,0 +1,63 @@
+FROM php:8.4-cli AS base
+
+RUN apt-get update && apt-get install -y \
+    libsqlite3-dev \
+    unzip \
+    curl \
+    supervisor \
+    && docker-php-ext-install pdo_sqlite pcntl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+
+# --- Build stage: install deps and compile assets ---
+FROM base AS build
+
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --no-scripts --no-interaction --prefer-dist
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+RUN composer dump-autoload --optimize \
+    && npm run build
+
+# --- Production stage: lean runtime ---
+FROM base AS production
+
+COPY --from=build /app /app
+
+ARG GIT_SHA=unknown
+RUN echo "${GIT_SHA}" > /app/.version
+
+# Remove node_modules (not needed at runtime)
+RUN rm -rf node_modules
+
+# Ensure writable directories exist
+RUN mkdir -p storage/logs \
+    storage/framework/{cache,sessions,views} \
+    bootstrap/cache \
+    database \
+    && chmod -R 775 storage bootstrap/cache database
+
+# Generate .env with app key and cache routes/views
+RUN cp .env.example .env \
+    && php artisan key:generate \
+    && php artisan route:cache \
+    && php artisan view:cache
+
+COPY .github/docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY .github/docker/entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# Ensure SQLite database exists in persistent data dir
+mkdir -p /data
+touch /data/database.sqlite
+ln -sf /data/database.sqlite /app/database/database.sqlite
+
+# Clear cached config so runtime env vars take effect
+php artisan config:clear --quiet
+
+# Run migrations
+php artisan migrate --force --quiet
+
+# Re-cache config with runtime env vars
+php artisan config:cache --quiet
+
+# Start supervisor (web server + queue worker)
+exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/.github/docker/supervisord.conf
+++ b/.github/docker/supervisord.conf
@@ -1,0 +1,23 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/var/run/supervisord.pid
+
+[program:web]
+command=php /app/artisan serve --host=0.0.0.0 --port=8080
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:queue-worker]
+command=php /app/artisan queue:work database --sleep=3 --tries=3 --max-time=3600
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Docker
+
+on:
+  push:
+    branches: [master, develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["laravel", "sail", "scaffold", "boilerplate"],
     "license": "MIT",
     "require": {
-        "php": "8.5.*",
+        "php": "^8.4",
         "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0"
     },


### PR DESCRIPTION
## Summary

Add Docker containerization and automated GHCR publishing, enabling deployment of Sail Scaffold as a pre-built Docker image — matching the same pattern used by claude-board.

## Changes

- **Multi-stage Dockerfile** (`.github/docker/Dockerfile`): Three-stage build (base → build → production) using `php:8.4-cli`, compiling frontend assets with Node.js 24 and installing Composer dependencies without dev packages
- **Supervisor config** (`.github/docker/supervisord.conf`): Runs both `php artisan serve` (port 8080) and `php artisan queue:work` in the same container
- **Entrypoint script** (`.github/docker/entrypoint.sh`): Handles SQLite persistence via `/data` volume symlink, runs migrations, and re-caches config with runtime environment variables
- **GitHub Actions workflow** (`.github/workflows/docker.yml`): Builds and pushes multi-platform images (amd64 + arm64) to `ghcr.io/tvup/sail-scaffold` on push to master/develop
- **PHP version constraint** relaxed from `8.5.*` to `^8.4` since PHP 8.5 Docker images are not yet available
- **`.dockerignore`** added to keep build context lean

## Technical Details

The container uses Supervisor to manage two processes (web server + queue worker) instead of claude-board's single-process approach, since Sail Scaffold requires background job processing for queue operations.

SQLite persistence follows the claude-board pattern: the `/data` volume is mounted externally, and the entrypoint symlinks `/data/database.sqlite` into the app's database directory.

## Testing

After merge, the image can be deployed with:

```yaml
sail-scaffold:
  image: ghcr.io/tvup/sail-scaffold:latest
  volumes:
    - sail-scaffold-data:/data
  environment:
    APP_ENV: production
    APP_URL: https://example.com
  ports:
    - "8091:8080"
```

Verify with:
- `curl http://localhost:8091/up` — health check
- `curl http://localhost:8091/` — welcome page
- `curl -s "http://localhost:8091/my-app"` — install script generation


🤖 Generated with [Claude Code](https://claude.com/claude-code)