### PR TITLE
Fix VTE escape sequences in prompt after install

### DIFF
--- a/resources/views/install.php
+++ b/resources/views/install.php
@@ -251,4 +251,5 @@ echo -e "${CYAN}    cd ${APP_NAME} && ./vendor/bin/sail up${NC}"
 echo ""
 
 # Drop into the project directory
+read -t 0.1 -n 10000 discard < /dev/tty 2>/dev/null || true
 exec $SHELL < /dev/tty


### PR DESCRIPTION
## Summary
- Flush pending terminal input buffer before `exec $SHELL` to prevent VTE device attribute responses from leaking into the new shell prompt
- Fixes the `VTE(7600)^[\^[[?61;1;21;22c` garbage appearing in the prompt when running the install script via `curl ... | bash` with commands with interactive "keyboard injections"

## Test plan
- [x] Run install script via `curl -s "http://localhost/example-app" | bash` in GNOME Terminal
- [x] Verify no VTE escape sequences appear in the prompt after completion
- [x] Verify `sudo` password prompt still works correctly
- [x] All 30 install tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)