### PR TITLE
Improve install message and add config export/import

### DIFF
--- a/app/Http/Controllers/Admin/ExportImportController.php
+++ b/app/Http/Controllers/Admin/ExportImportController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\BoilerplateCommand;
+use App\Models\BoilerplateDockerService;
+use App\Models\BoilerplateFile;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\View\View;
+
+class ExportImportController extends Controller
+{
+    public function index(): View
+    {
+        return view('admin.share');
+    }
+
+    public function export(): JsonResponse
+    {
+        $data = [
+            'sail_scaffold_version' => '1.0',
+            'exported_at' => now()->toIso8601String(),
+            'files' => BoilerplateFile::query()
+                ->orderBy('path')
+                ->get(['path', 'content', 'enabled']),
+            'docker_services' => BoilerplateDockerService::query()
+                ->orderBy('name')
+                ->get(['name', 'config', 'enabled']),
+            'commands' => BoilerplateCommand::query()
+                ->orderBy('sort_order')
+                ->get(['name', 'command', 'sort_order', 'enabled']),
+        ];
+
+        return response()
+            ->json($data, options: JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+            ->header('Content-Disposition', 'attachment; filename=sail-scaffold-config.json');
+    }
+
+    public function import(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'config_file' => ['required', 'file', 'mimes:json', 'max:1024'],
+        ]);
+
+        $json = json_decode($request->file('config_file')->getContent(), true);
+
+        if (! is_array($json)) {
+            return back()->withErrors(['config_file' => 'Invalid JSON file.']);
+        }
+
+        DB::transaction(function () use ($json) {
+            if (isset($json['files']) && is_array($json['files'])) {
+                BoilerplateFile::query()->truncate();
+                foreach ($json['files'] as $file) {
+                    BoilerplateFile::query()->create([
+                        'path' => $file['path'],
+                        'content' => $file['content'] ?? null,
+                        'enabled' => $file['enabled'] ?? true,
+                    ]);
+                }
+            }
+
+            if (isset($json['docker_services']) && is_array($json['docker_services'])) {
+                BoilerplateDockerService::query()->truncate();
+                foreach ($json['docker_services'] as $service) {
+                    BoilerplateDockerService::query()->create([
+                        'name' => $service['name'],
+                        'config' => $service['config'],
+                        'enabled' => $service['enabled'] ?? true,
+                    ]);
+                }
+            }
+
+            if (isset($json['commands']) && is_array($json['commands'])) {
+                BoilerplateCommand::query()->truncate();
+                foreach ($json['commands'] as $command) {
+                    BoilerplateCommand::query()->create([
+                        'name' => $command['name'],
+                        'command' => $command['command'],
+                        'sort_order' => $command['sort_order'] ?? 0,
+                        'enabled' => $command['enabled'] ?? true,
+                    ]);
+                }
+            }
+        });
+
+        return redirect()->route('admin.index')->with('success', 'Configuration imported successfully.');
+    }
+}

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -13,13 +13,6 @@
             <span class="text-gray-500 text-sm"> / {{ $sailServices->count() }} active</span>
         </a>
 
-        <a href="{{ route('admin.files') }}" class="block bg-gray-800 rounded-lg p-6 border border-gray-700 hover:border-cyan-500 transition-colors">
-            <h2 class="text-lg font-semibold text-white mb-2">Custom Files</h2>
-            <p class="text-gray-400 text-sm mb-4">Files and directories added to new projects</p>
-            <span class="text-cyan-400 font-mono text-2xl">{{ $files->where('enabled', true)->count() }}</span>
-            <span class="text-gray-500 text-sm"> / {{ $files->count() }} active</span>
-        </a>
-
         <a href="{{ route('admin.composer-packages') }}" class="block bg-gray-800 rounded-lg p-6 border border-gray-700 hover:border-cyan-500 transition-colors">
             <h2 class="text-lg font-semibold text-white mb-2">Composer Packages</h2>
             <p class="text-gray-400 text-sm mb-4">PHP packages installed in new projects</p>
@@ -32,6 +25,13 @@
             <p class="text-gray-400 text-sm mb-4">JavaScript packages installed in new projects</p>
             <span class="text-cyan-400 font-mono text-2xl">{{ $npmPackages->where('enabled', true)->count() }}</span>
             <span class="text-gray-500 text-sm"> / {{ $npmPackages->count() }} active</span>
+        </a>
+
+        <a href="{{ route('admin.files') }}" class="block bg-gray-800 rounded-lg p-6 border border-gray-700 hover:border-cyan-500 transition-colors">
+            <h2 class="text-lg font-semibold text-white mb-2">Custom Files</h2>
+            <p class="text-gray-400 text-sm mb-4">Files and directories added to new projects</p>
+            <span class="text-cyan-400 font-mono text-2xl">{{ $files->where('enabled', true)->count() }}</span>
+            <span class="text-gray-500 text-sm"> / {{ $files->count() }} active</span>
         </a>
 
         <a href="{{ route('admin.docker-services') }}" class="block bg-gray-800 rounded-lg p-6 border border-gray-700 hover:border-cyan-500 transition-colors">

--- a/resources/views/admin/share.blade.php
+++ b/resources/views/admin/share.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.admin')
+
+@section('title', 'Share Configuration')
+
+@section('content')
+    <h1 class="text-2xl font-bold text-cyan-400 mb-6">Share Configuration</h1>
+    <p class="text-gray-400 text-sm mb-8">Export your custom files, Docker services, and commands as a JSON file to share with colleagues, or import a configuration from someone else.</p>
+
+    {{-- Export --}}
+    <div class="bg-gray-800 rounded-lg p-6 border border-gray-700 mb-8">
+        <h2 class="text-lg font-semibold text-white mb-2">Export</h2>
+        <p class="text-gray-400 text-sm mb-4">Download your current configuration as a JSON file.</p>
+        <a href="{{ route('admin.export') }}" class="inline-block bg-cyan-600 hover:bg-cyan-700 text-white px-4 py-2 rounded font-medium text-sm">Download JSON</a>
+    </div>
+
+    {{-- Import --}}
+    <div class="bg-gray-800 rounded-lg p-6 border border-gray-700">
+        <h2 class="text-lg font-semibold text-white mb-2">Import</h2>
+        <p class="text-gray-400 text-sm mb-4">Upload a JSON configuration file. This will replace all existing files, Docker services, and commands.</p>
+
+        <form action="{{ route('admin.import') }}" method="POST" enctype="multipart/form-data" class="flex items-end gap-3" onsubmit="return confirm('This will replace all existing files, Docker services, and commands. Continue?')">
+            @csrf
+            <div>
+                <label for="config_file" class="block text-sm text-gray-400 mb-1">Configuration file</label>
+                <input type="file" name="config_file" id="config_file" accept=".json" required class="text-sm text-gray-400 file:mr-3 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-medium file:bg-gray-700 file:text-gray-300 hover:file:bg-gray-600 file:cursor-pointer">
+            </div>
+            <button type="submit" class="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded font-medium text-sm whitespace-nowrap">Import</button>
+        </form>
+    </div>
+@endsection

--- a/resources/views/install.php
+++ b/resources/views/install.php
@@ -251,7 +251,7 @@ else
     echo ""
     echo -e "${CYAN}You can fix these manually after starting the project.${NC}"
 fi
-echo -e "${CYAN}    cd ${APP_NAME} && ./vendor/bin/sail up${NC}"
+echo -e "${CYAN}Get started with: cd ${APP_NAME} && ./vendor/bin/sail up${NC}"
 echo ""
 
 # Return to original directory and drop into a clean shell

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -18,6 +18,7 @@
                     <a href="{{ route('admin.npm-packages') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">npm</a>
                     <a href="{{ route('admin.docker-services') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Docker Services</a>
                     <a href="{{ route('admin.commands') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Commands</a>
+                    <a href="{{ route('admin.share') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Share</a>
                     <span class="text-gray-600">|</span>
                     <a href="{{ url('/') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">&larr; Front Page</a>
                 </div>

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -13,9 +13,9 @@
                 <a href="{{ route('admin.index') }}" class="text-cyan-400 font-bold text-lg">Boilerplate Admin</a>
                 <div class="flex space-x-4">
                     <a href="{{ route('admin.sail-services') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Sail Services</a>
-                    <a href="{{ route('admin.files') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Files</a>
                     <a href="{{ route('admin.composer-packages') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Composer</a>
                     <a href="{{ route('admin.npm-packages') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">npm</a>
+                    <a href="{{ route('admin.files') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Files</a>
                     <a href="{{ route('admin.docker-services') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Docker Services</a>
                     <a href="{{ route('admin.commands') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Commands</a>
                     <a href="{{ route('admin.share') }}" class="text-gray-300 hover:text-white px-3 py-2 text-sm">Share</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Admin\BoilerplateController;
+use App\Http\Controllers\Admin\ExportImportController;
 use App\Http\Controllers\InstallScriptController;
 use App\Http\Controllers\WelcomeController;
 use Illuminate\Support\Facades\Route;
@@ -10,6 +11,9 @@ Route::get('/', WelcomeController::class);
 // Admin GUI
 Route::prefix('admin')->name('admin.')->group(function () {
     Route::get('/', [BoilerplateController::class, 'index'])->name('index');
+    Route::get('/share', [ExportImportController::class, 'index'])->name('share');
+    Route::get('/export', [ExportImportController::class, 'export'])->name('export');
+    Route::post('/import', [ExportImportController::class, 'import'])->name('import');
 
     Route::get('/sail-services', [BoilerplateController::class, 'sailServices'])->name('sail-services');
     Route::post('/sail-services', [BoilerplateController::class, 'storeSailService'])->name('sail-services.store');


### PR DESCRIPTION
## Summary
- Add descriptive "Get started with:" prefix to the final command shown after installation
- Add Share page in admin with export/import of configuration (files, Docker services, commands) as JSON

## Test plan
- [x] All 57 tests pass
- [x] Pint passes
- [x] Export config, inspect JSON, import into same instance — verify data unchanged
- [x] Run install script and verify completion message

🤖 Generated with [Claude Code](https://claude.com/claude-code)